### PR TITLE
Fix daylight sky timing

### DIFF
--- a/apps/steven-junio/src/app/components/skyScene/celestialTime.test.ts
+++ b/apps/steven-junio/src/app/components/skyScene/celestialTime.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getCelestialState, getSkySunPosition } from "./celestialTime.ts";
+
+test("morning sky uses the real above-horizon sun position", () => {
+  const morning = new Date("2026-07-16T07:36:00-07:00");
+  const state = getCelestialState(morning);
+
+  assert.equal(state.body, "sun");
+  assert.ok(
+    state.bodyPosition[1] < 0,
+    "the decorative arc should preserve its existing visual placement",
+  );
+  assert.ok(
+    state.skySunPosition[1] > 25,
+    "the sky shader sun should be well above the horizon",
+  );
+});
+
+test("real sky sun position crosses the horizon around sunrise and sunset", () => {
+  const beforeSunrise = getSkySunPosition(
+    new Date("2026-07-16T05:30:00-07:00"),
+  );
+  const afterSunrise = getSkySunPosition(
+    new Date("2026-07-16T06:30:00-07:00"),
+  );
+  const beforeSunset = getSkySunPosition(
+    new Date("2026-07-16T20:00:00-07:00"),
+  );
+  const afterSunset = getSkySunPosition(
+    new Date("2026-07-16T21:00:00-07:00"),
+  );
+
+  assert.ok(beforeSunrise[1] < 0);
+  assert.ok(afterSunrise[1] > 0);
+  assert.ok(beforeSunset[1] > 0);
+  assert.ok(afterSunset[1] < 0);
+});
+
+test("sky sun vector stays on the shader's celestial sphere", () => {
+  const position = getSkySunPosition(
+    new Date("2026-07-16T13:13:00-07:00"),
+  );
+  const distance = Math.hypot(...position);
+
+  assert.ok(Math.abs(distance - 100) < 0.000_001);
+});

--- a/apps/steven-junio/src/app/components/skyScene/celestialTime.ts
+++ b/apps/steven-junio/src/app/components/skyScene/celestialTime.ts
@@ -1,4 +1,4 @@
-import { getTimes } from "suncalc";
+import { getPosition, getTimes } from "suncalc";
 
 export const PORTFOLIO_LOCATION = {
   city: "San Jose, CA",
@@ -25,6 +25,7 @@ const ARC_WIDTH = 36;
 const HORIZON_HEIGHT = -8;
 const ARC_HEIGHT = 19;
 const SCENE_DEPTH = -20;
+const SKY_SUN_DISTANCE = 100;
 
 function clamp(value: number, minimum = 0, maximum = 1) {
   return Math.min(maximum, Math.max(minimum, value));
@@ -70,14 +71,21 @@ function getArcPosition(progress: number): [number, number, number] {
   ];
 }
 
-function getBelowHorizonSunPosition(progress: number): [number, number, number] {
-  const normalizedProgress = clamp(progress);
-  const angle = Math.PI * normalizedProgress;
+export function getSkySunPosition(date: Date): [number, number, number] {
+  const { altitude, azimuth } = getPosition(
+    date,
+    PORTFOLIO_LOCATION.latitude,
+    PORTFOLIO_LOCATION.longitude,
+  );
+  const altitudeRadians = (altitude * Math.PI) / 180;
+  const azimuthRadians = (azimuth * Math.PI) / 180;
+  const horizontalDistance =
+    Math.cos(altitudeRadians) * SKY_SUN_DISTANCE;
 
   return [
-    ARC_WIDTH / 2 - ARC_WIDTH * normalizedProgress,
-    -HORIZON_HEIGHT - Math.sin(angle) * ARC_HEIGHT,
-    SCENE_DEPTH,
+    Math.sin(azimuthRadians) * horizontalDistance,
+    Math.sin(altitudeRadians) * SKY_SUN_DISTANCE,
+    -Math.cos(azimuthRadians) * horizontalDistance,
   ];
 }
 
@@ -98,7 +106,7 @@ export function getCelestialState(now = new Date()): CelestialState {
     return {
       body: "sun",
       bodyPosition: position,
-      skySunPosition: position,
+      skySunPosition: getSkySunPosition(now),
       sunrise: today.sunrise,
       sunset: today.sunset,
       nextTransition: today.sunset,
@@ -115,7 +123,7 @@ export function getCelestialState(now = new Date()): CelestialState {
   return {
     body: "moon",
     bodyPosition: getArcPosition(nightProgress),
-    skySunPosition: getBelowHorizonSunPosition(nightProgress),
+    skySunPosition: getSkySunPosition(now),
     sunrise: now < today.sunrise ? today.sunrise : tomorrow.sunrise,
     sunset: today.sunset,
     nextTransition: nightEnds,

--- a/apps/steven-junio/tsconfig.json
+++ b/apps/steven-junio/tsconfig.json
@@ -12,6 +12,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "target": "ES2023",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## What changed
- calculate the Three.js sky shader position from San Jose solar altitude and azimuth
- keep the decorative sun and moon on the existing responsive visual arc
- add regression coverage for the reported 7:36 AM morning state and sunrise/sunset horizon crossings

## Root cause
The decorative display arc started at a negative Y coordinate and was also passed into the physically based sky shader. The visible body correctly switched to the sun at sunrise, but the shader interpreted that artificial position as below the horizon for roughly two additional hours.

## Impact
The sky now becomes daylight at the real San Jose sunrise without requiring a weather API or changing the visible celestial layout.

## Validation
- Node solar-position regression tests: 3 passed
- npm run typecheck
- npm run lint
- npm run build