### PR TITLE
Add weather-aware portfolio sky

### DIFF
--- a/apps/steven-junio/package.json
+++ b/apps/steven-junio/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",

--- a/apps/steven-junio/src/app/api/weather/route.ts
+++ b/apps/steven-junio/src/app/api/weather/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import {
+  buildWeatherSnapshot,
+  FALLBACK_WEATHER,
+  type NwsGridData,
+  type NwsObservation,
+} from "../../components/skyScene/weather";
+
+const LOCATION = "37.3382,-121.8863";
+const NWS_HEADERS = {
+  Accept: "application/geo+json",
+  "User-Agent":
+    "stevenjunio.com weather scene (https://www.stevenjunio.com/contact)",
+};
+
+type NwsFeature<T = Record<string, unknown>> = {
+  properties?: T;
+};
+
+type NwsPointMetadata = {
+  forecastGridData?: string;
+  observationStations?: string;
+};
+
+type NwsStationMetadata = {
+  stationIdentifier?: string;
+};
+
+type NwsFeatureCollection<T> = {
+  features?: Array<NwsFeature<T>>;
+};
+
+async function fetchNwsJson<T>(
+  url: string,
+  revalidate: number,
+): Promise<T> {
+  const response = await fetch(url, {
+    headers: NWS_HEADERS,
+    next: { revalidate },
+  });
+
+  if (!response.ok) {
+    throw new Error(`NWS request failed with ${response.status}.`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export async function GET() {
+  try {
+    const point = await fetchNwsJson<NwsFeature<NwsPointMetadata>>(
+      `https://api.weather.gov/points/${LOCATION}`,
+      86_400,
+    );
+    const forecastGridData = point.properties?.forecastGridData;
+    const observationStations = point.properties?.observationStations;
+
+    if (
+      typeof forecastGridData !== "string" ||
+      typeof observationStations !== "string"
+    ) {
+      throw new Error("NWS point metadata is incomplete.");
+    }
+
+    const stations = await fetchNwsJson<
+      NwsFeatureCollection<NwsStationMetadata>
+    >(observationStations, 86_400);
+    const stationFeatures = stations.features;
+    const stationId = stationFeatures?.[0]?.properties?.stationIdentifier;
+
+    if (typeof stationId !== "string") {
+      throw new Error("NWS observation station is unavailable.");
+    }
+
+    const [observationResult, gridResult] = await Promise.allSettled([
+      fetchNwsJson<NwsFeature<NwsObservation>>(
+        `https://api.weather.gov/stations/${stationId}/observations/latest`,
+        300,
+      ),
+      fetchNwsJson<NwsFeature<NwsGridData>>(forecastGridData, 3_600),
+    ]);
+    const observation: NwsObservation | null =
+      observationResult.status === "fulfilled"
+        ? observationResult.value.properties ?? null
+        : null;
+    const grid: NwsGridData | null =
+      gridResult.status === "fulfilled"
+        ? gridResult.value.properties ?? null
+        : null;
+
+    if (!observation && !grid) {
+      throw new Error("NWS weather data is unavailable.");
+    }
+
+    return NextResponse.json(buildWeatherSnapshot(observation, grid), {
+      headers: {
+        "Cache-Control": "public, s-maxage=300, stale-while-revalidate=900",
+      },
+    });
+  } catch {
+    return NextResponse.json(FALLBACK_WEATHER, {
+      headers: {
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=600",
+      },
+    });
+  }
+}

--- a/apps/steven-junio/src/app/components/TimeOfDayScene.tsx
+++ b/apps/steven-junio/src/app/components/TimeOfDayScene.tsx
@@ -16,6 +16,11 @@ import {
   getCelestialState,
   type CelestialState,
 } from "./skyScene/celestialTime";
+import {
+  FALLBACK_WEATHER,
+  getWeatherVisualState,
+  type WeatherSnapshot,
+} from "./skyScene/weather";
 
 type CanvasReadyProps = {
   onReady: () => void;
@@ -36,6 +41,8 @@ function CanvasReady({ onReady }: CanvasReadyProps) {
 
 const TimeOfDayScene = () => {
   const [celestial, setCelestial] = useState<CelestialState | null>(null);
+  const [weather, setWeather] =
+    useState<WeatherSnapshot>(FALLBACK_WEATHER);
   const [canvasReady, setCanvasReady] = useState(false);
 
   useEffect(() => {
@@ -54,6 +61,38 @@ const TimeOfDayScene = () => {
     };
   }, []);
 
+  useEffect(() => {
+    let isMounted = true;
+    let activeController: AbortController | null = null;
+
+    const updateWeather = async () => {
+      activeController?.abort();
+      activeController = new AbortController();
+
+      try {
+        const response = await fetch("/api/weather", {
+          signal: activeController.signal,
+        });
+
+        if (!response.ok) return;
+
+        const nextWeather = (await response.json()) as WeatherSnapshot;
+        if (isMounted) setWeather(nextWeather);
+      } catch {
+        // Keep the last known or polished fallback state when weather is offline.
+      }
+    };
+
+    void updateWeather();
+    const timer = window.setInterval(updateWeather, 5 * 60 * 1000);
+
+    return () => {
+      isMounted = false;
+      activeController?.abort();
+      window.clearInterval(timer);
+    };
+  }, []);
+
   const handleContextMenu = useCallback((event: MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
   }, []);
@@ -67,6 +106,7 @@ const TimeOfDayScene = () => {
     celestial.body === "moon"
       ? "linear-gradient(to bottom, #080b16 0%, #171927 55%, #312c2b 100%)"
       : "linear-gradient(to bottom, #60a5fa 0%, #93c5fd 45%, #9ca3af 100%)";
+  const weatherVisual = getWeatherVisualState(weather, celestial.body);
 
   return (
     <div
@@ -82,13 +122,24 @@ const TimeOfDayScene = () => {
         }}
       >
         <PerspectiveCamera makeDefault position={[0, 0, 10]} />
-        <Scene celestial={celestial} />
+        <Scene celestial={celestial} weather={weatherVisual} />
 
-        <CloudsComponent numberOfClouds={100} />
+        <CloudsComponent
+          numberOfClouds={weatherVisual.cloudCount}
+          opacity={weatherVisual.cloudOpacity}
+          color={weatherVisual.cloudColor}
+          speed={weatherVisual.cloudSpeed}
+        />
         <CanvasReady onReady={handleCanvasReady} />
       </Canvas>
 
-      <CelestialControl celestial={celestial} />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 z-[1] mix-blend-multiply"
+        style={{ background: weatherVisual.skyTint }}
+      />
+
+      <CelestialControl celestial={celestial} weather={weather} />
     </div>
   );
 };

--- a/apps/steven-junio/src/app/components/skyScene/CelestialControl.tsx
+++ b/apps/steven-junio/src/app/components/skyScene/CelestialControl.tsx
@@ -6,9 +6,11 @@ import {
   PORTFOLIO_LOCATION,
   type CelestialState,
 } from "./celestialTime";
+import type { WeatherSnapshot } from "./weather";
 
 type CelestialControlProps = {
   celestial: CelestialState;
+  weather: WeatherSnapshot;
 };
 
 type LabelPlacement =
@@ -42,7 +44,10 @@ function placementsMatch(
   return false;
 }
 
-export default function CelestialControl({ celestial }: CelestialControlProps) {
+export default function CelestialControl({
+  celestial,
+  weather,
+}: CelestialControlProps) {
   const [currentTime, setCurrentTime] = useState(() => new Date());
   const [labelPlacement, setLabelPlacement] =
     useState<LabelPlacement | null>(null);
@@ -180,7 +185,7 @@ export default function CelestialControl({ celestial }: CelestialControlProps) {
       <div
         ref={labelRef}
         role="status"
-        aria-label={`Steven's home time is ${formatPortfolioTime(currentTime, false, true)} in ${PORTFOLIO_LOCATION.city}`}
+        aria-label={`Steven's home time is ${formatPortfolioTime(currentTime, false, true)} in ${PORTFOLIO_LOCATION.city}. Current conditions: ${weather.condition}.`}
         style={attachedStyle}
         className={`pointer-events-none fixed z-20 whitespace-nowrap rounded-full border border-white/10 bg-slate-950/45 px-2.5 py-1 text-[11px] font-medium tracking-wide text-white/80 shadow-sm backdrop-blur-md transition-opacity sm:text-xs ${
           labelPlacement
@@ -196,6 +201,9 @@ export default function CelestialControl({ celestial }: CelestialControlProps) {
         <span className="tabular-nums">
           {formatPortfolioTime(currentTime, false, true)}
         </span>
+        {!weather.isFallback && (
+          <span className="hidden sm:inline"> · {weather.condition}</span>
+        )}
       </div>
     </>
   );

--- a/apps/steven-junio/src/app/components/skyScene/Clouds.tsx
+++ b/apps/steven-junio/src/app/components/skyScene/Clouds.tsx
@@ -3,12 +3,24 @@
 import { Cloud } from "@react-three/drei";
 import { memo, useMemo } from "react";
 
+type CloudsComponentProps = {
+  numberOfClouds: number;
+  opacity: number;
+  color: string;
+  speed: number;
+};
+
 function seededRandom(seed: number) {
   const value = Math.sin(seed * 12_989.8) * 43_758.5453;
   return value - Math.floor(value);
 }
 
-function CloudsComponent({ numberOfClouds = 1 }) {
+function CloudsComponent({
+  numberOfClouds,
+  opacity,
+  color,
+  speed,
+}: CloudsComponentProps) {
   const cloudPositions = useMemo<[number, number, number][]>(
     () =>
       Array.from({ length: numberOfClouds }, (_, index) => [
@@ -25,9 +37,11 @@ function CloudsComponent({ numberOfClouds = 1 }) {
       {cloudPositions.map((position, index) => (
         <Cloud
           key={index}
-          opacity={0.3}
-          speed={0.1}
-          color="white"
+          seed={index + 1}
+          segments={8}
+          opacity={opacity}
+          speed={speed}
+          color={color}
           position={position}
         />
       ))}

--- a/apps/steven-junio/src/app/components/skyScene/MainScene.tsx
+++ b/apps/steven-junio/src/app/components/skyScene/MainScene.tsx
@@ -4,12 +4,14 @@ import { OrbitControls, Sky, Stars } from "@react-three/drei";
 import { Suspense, useMemo } from "react";
 import { Vector3 } from "three";
 import type { CelestialState } from "./celestialTime";
+import type { WeatherVisualState } from "./weather";
 
 type SceneProps = {
   celestial: CelestialState;
+  weather: WeatherVisualState;
 };
 
-export default function Scene({ celestial }: SceneProps) {
+export default function Scene({ celestial, weather }: SceneProps) {
   const skySunPosition = useMemo(
     () => new Vector3(...celestial.skySunPosition),
     [celestial.skySunPosition],
@@ -20,8 +22,10 @@ export default function Scene({ celestial }: SceneProps) {
   return (
     <Suspense fallback={null}>
       <Sky
-        turbidity={isNight ? 4 : 2}
-        rayleigh={isNight ? 0.25 : 1.4}
+        turbidity={weather.turbidity}
+        rayleigh={weather.rayleigh}
+        mieCoefficient={weather.mieCoefficient}
+        mieDirectionalG={weather.mieDirectionalG}
         sunPosition={skySunPosition}
         distance={35}
       />

--- a/apps/steven-junio/src/app/components/skyScene/weather.test.ts
+++ b/apps/steven-junio/src/app/components/skyScene/weather.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildWeatherSnapshot,
+  FALLBACK_WEATHER,
+  getWeatherVisualState,
+  valueForTime,
+} from "./weather.ts";
+
+const morning = new Date("2026-07-16T07:45:00-07:00");
+
+test("selects the NWS value whose validity interval contains the current time", () => {
+  const value = valueForTime(
+    [
+      {
+        validTime: "2026-07-16T13:00:00+00:00/PT1H",
+        value: 12,
+      },
+      {
+        validTime: "2026-07-16T14:00:00+00:00/PT3H",
+        value: 28,
+      },
+    ],
+    morning,
+  );
+
+  assert.equal(value, 28);
+});
+
+test("prefers a fresh clear observation over forecast cloud cover", () => {
+  const snapshot = buildWeatherSnapshot(
+    {
+      timestamp: "2026-07-16T14:25:00+00:00",
+      textDescription: "Clear",
+      cloudLayers: [{ amount: "CLR" }],
+      visibility: { value: 16_093.44 },
+      windSpeed: { value: 0 },
+      presentWeather: [],
+    },
+    {
+      skyCover: {
+        values: [
+          {
+            validTime: "2026-07-16T14:00:00+00:00/PT3H",
+            value: 40,
+          },
+        ],
+      },
+    },
+    morning,
+  );
+
+  assert.equal(snapshot.condition, "Clear");
+  assert.equal(snapshot.kind, "clear");
+  assert.equal(snapshot.cloudCover, 0);
+  assert.equal(snapshot.visibilityKm, 16.09344);
+  assert.equal(snapshot.isFallback, false);
+});
+
+test("uses forecast sky cover when the observation is stale", () => {
+  const snapshot = buildWeatherSnapshot(
+    {
+      timestamp: "2026-07-16T10:00:00+00:00",
+      textDescription: "Clear",
+      cloudLayers: [{ amount: "CLR" }],
+    },
+    {
+      skyCover: {
+        values: [
+          {
+            validTime: "2026-07-16T14:00:00+00:00/PT3H",
+            value: 82,
+          },
+        ],
+      },
+    },
+    morning,
+  );
+
+  assert.equal(snapshot.cloudCover, 82);
+  assert.equal(snapshot.kind, "cloudy");
+  assert.equal(snapshot.isFallback, false);
+});
+
+test("clear daylight remains blue and uses only a few faint clouds", () => {
+  const visual = getWeatherVisualState(
+    {
+      ...FALLBACK_WEATHER,
+      condition: "Clear",
+      cloudCover: 0,
+      isFallback: false,
+    },
+    "sun",
+  );
+
+  assert.ok(visual.rayleigh > 2);
+  assert.ok(visual.mieCoefficient < 0.002);
+  assert.ok(visual.cloudCount <= 5);
+  assert.match(visual.skyTint, /rgba\(26, 115, 205/);
+});
+
+test("fog increases haze and cloud presence without removing the blue tint", () => {
+  const visual = getWeatherVisualState(
+    {
+      ...FALLBACK_WEATHER,
+      condition: "Fog",
+      kind: "fog",
+      cloudCover: 100,
+      visibilityKm: 1,
+      isFallback: false,
+    },
+    "sun",
+  );
+
+  assert.ok(visual.turbidity > 4);
+  assert.ok(visual.mieCoefficient > 0.006);
+  assert.ok(visual.cloudCount > 60);
+  assert.notEqual(visual.skyTint, "transparent");
+});

--- a/apps/steven-junio/src/app/components/skyScene/weather.ts
+++ b/apps/steven-junio/src/app/components/skyScene/weather.ts
@@ -1,0 +1,280 @@
+import type { CelestialBody } from "./celestialTime";
+
+export type WeatherKind =
+  | "clear"
+  | "cloudy"
+  | "fog"
+  | "rain"
+  | "snow"
+  | "storm";
+
+export type WeatherSnapshot = {
+  condition: string;
+  kind: WeatherKind;
+  cloudCover: number;
+  visibilityKm: number | null;
+  windSpeedKph: number | null;
+  observedAt: string | null;
+  isFallback: boolean;
+};
+
+export type WeatherVisualState = {
+  turbidity: number;
+  rayleigh: number;
+  mieCoefficient: number;
+  mieDirectionalG: number;
+  cloudCount: number;
+  cloudOpacity: number;
+  cloudColor: string;
+  cloudSpeed: number;
+  skyTint: string;
+};
+
+type NwsValue<T> = {
+  validTime: string;
+  value: T;
+};
+
+type NwsCloudLayer = {
+  amount?: string | null;
+};
+
+export type NwsObservation = {
+  timestamp?: string | null;
+  textDescription?: string | null;
+  cloudLayers?: NwsCloudLayer[] | null;
+  visibility?: { value?: number | null } | null;
+  windSpeed?: { value?: number | null } | null;
+  presentWeather?: Array<{ weather?: string | null }> | null;
+};
+
+export type NwsGridData = {
+  skyCover?: { values?: Array<NwsValue<number | null>> };
+  weather?: {
+    values?: Array<
+      NwsValue<
+        Array<{
+          weather?: string | null;
+          intensity?: string | null;
+        }> | null
+      >
+    >;
+  };
+};
+
+const CLOUD_LAYER_COVER: Record<string, number> = {
+  CLR: 0,
+  SKC: 0,
+  FEW: 20,
+  SCT: 45,
+  BKN: 75,
+  OVC: 100,
+  VV: 100,
+};
+
+export const FALLBACK_WEATHER: WeatherSnapshot = {
+  condition: "Mostly clear",
+  kind: "clear",
+  cloudCover: 15,
+  visibilityKm: 16,
+  windSpeedKph: 0,
+  observedAt: null,
+  isFallback: true,
+};
+
+function clamp(value: number, minimum = 0, maximum = 100) {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function parseDuration(duration: string) {
+  const match =
+    /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(
+      duration,
+    );
+
+  if (!match) return null;
+
+  return (
+    (Number(match[1] || 0) * 24 * 60 * 60 +
+      Number(match[2] || 0) * 60 * 60 +
+      Number(match[3] || 0) * 60 +
+      Number(match[4] || 0)) *
+    1000
+  );
+}
+
+export function valueForTime<T>(
+  values: Array<NwsValue<T>> | undefined,
+  now: Date,
+) {
+  if (!values?.length) return null;
+
+  for (const entry of values) {
+    const [startText, durationText] = entry.validTime.split("/");
+    const start = new Date(startText).getTime();
+    const duration = durationText ? parseDuration(durationText) : null;
+
+    if (
+      Number.isFinite(start) &&
+      duration !== null &&
+      now.getTime() >= start &&
+      now.getTime() < start + duration
+    ) {
+      return entry.value;
+    }
+  }
+
+  return null;
+}
+
+function cloudCoverFromLayers(layers: NwsCloudLayer[] | null | undefined) {
+  const values =
+    layers
+      ?.map((layer) =>
+        layer.amount ? CLOUD_LAYER_COVER[layer.amount.toUpperCase()] : undefined,
+      )
+      .filter((value): value is number => value !== undefined) ?? [];
+
+  return values.length ? Math.max(...values) : null;
+}
+
+function classifyWeather(
+  description: string,
+  cloudCover: number,
+  visibilityKm: number | null,
+): WeatherKind {
+  const normalized = description.toLowerCase();
+
+  if (/thunder|tornado|squall/.test(normalized)) return "storm";
+  if (/snow|sleet|ice|freezing/.test(normalized)) return "snow";
+  if (/rain|drizzle|shower/.test(normalized)) return "rain";
+  if (
+    /fog|mist|haze|smoke|dust/.test(normalized) ||
+    (visibilityKm !== null && visibilityKm < 5)
+  ) {
+    return "fog";
+  }
+  if (/cloud|overcast/.test(normalized) || cloudCover >= 55) return "cloudy";
+
+  return "clear";
+}
+
+function gridWeatherDescription(grid: NwsGridData, now: Date) {
+  const weather = valueForTime(grid.weather?.values, now)?.find(
+    (entry) => entry.weather,
+  );
+
+  if (!weather?.weather) return null;
+
+  const intensity =
+    weather.intensity && weather.intensity !== "none"
+      ? `${weather.intensity} `
+      : "";
+
+  return `${intensity}${weather.weather}`.replaceAll("_", " ");
+}
+
+export function buildWeatherSnapshot(
+  observation: NwsObservation | null,
+  grid: NwsGridData | null,
+  now = new Date(),
+): WeatherSnapshot {
+  const observedAt = observation?.timestamp
+    ? new Date(observation.timestamp)
+    : null;
+  const observationIsFresh =
+    observedAt !== null &&
+    Number.isFinite(observedAt.getTime()) &&
+    now.getTime() - observedAt.getTime() <= 2 * 60 * 60 * 1000;
+  const observedCloudCover = observationIsFresh
+    ? cloudCoverFromLayers(observation?.cloudLayers)
+    : null;
+  const forecastCloudCover = grid
+    ? valueForTime(grid.skyCover?.values, now)
+    : null;
+  const cloudCover = clamp(
+    observedCloudCover ?? forecastCloudCover ?? FALLBACK_WEATHER.cloudCover,
+  );
+  const visibilityKm =
+    observationIsFresh && observation?.visibility?.value != null
+      ? observation.visibility.value / 1000
+      : null;
+  const presentWeather =
+    observationIsFresh
+      ? observation?.presentWeather
+          ?.map((entry) => entry.weather)
+          .filter(Boolean)
+          .join(", ")
+      : null;
+  const condition =
+    presentWeather ||
+    (observationIsFresh ? observation?.textDescription : null) ||
+    (grid ? gridWeatherDescription(grid, now) : null) ||
+    (cloudCover < 20
+      ? "Clear"
+      : cloudCover < 55
+        ? "Partly cloudy"
+        : "Cloudy");
+
+  return {
+    condition,
+    kind: classifyWeather(condition, cloudCover, visibilityKm),
+    cloudCover,
+    visibilityKm,
+    windSpeedKph:
+      observationIsFresh && observation?.windSpeed?.value != null
+        ? observation.windSpeed.value
+        : null,
+    observedAt: observationIsFresh ? observedAt.toISOString() : null,
+    isFallback: !observationIsFresh && forecastCloudCover === null,
+  };
+}
+
+export function getWeatherVisualState(
+  weather: WeatherSnapshot,
+  body: CelestialBody,
+): WeatherVisualState {
+  const cloudiness = clamp(weather.cloudCover) / 100;
+  const lowVisibility =
+    weather.visibilityKm === null
+      ? 0
+      : clamp((10 - weather.visibilityKm) / 10, 0, 1);
+  const severeAtmosphere =
+    weather.kind === "fog"
+      ? 1
+      : weather.kind === "rain" || weather.kind === "snow"
+        ? 0.75
+        : weather.kind === "storm"
+          ? 1
+          : 0;
+  const atmosphere = Math.max(lowVisibility, severeAtmosphere);
+  const isNight = body === "moon";
+
+  return {
+    turbidity: isNight
+      ? 4 + atmosphere
+      : 1.25 + cloudiness * 2.5 + atmosphere * 1.25,
+    rayleigh: isNight
+      ? 0.25
+      : 2.45 - cloudiness * 1.15 - atmosphere * 0.35,
+    mieCoefficient: isNight
+      ? 0.004
+      : 0.0015 + cloudiness * 0.0035 + atmosphere * 0.002,
+    mieDirectionalG: 0.68 + cloudiness * 0.08 + atmosphere * 0.04,
+    cloudCount: Math.round(4 + cloudiness * 52 + atmosphere * 10),
+    cloudOpacity: 0.08 + cloudiness * 0.22 + atmosphere * 0.07,
+    cloudColor:
+      weather.kind === "storm"
+        ? "#aeb8c2"
+        : weather.kind === "rain" || weather.kind === "snow"
+          ? "#c8d0d8"
+          : "#f5f8fb",
+    cloudSpeed: Math.min(
+      0.2,
+      0.025 + (weather.windSpeedKph ?? 0) / 300,
+    ),
+    skyTint: isNight
+      ? "transparent"
+      : `linear-gradient(to bottom, rgba(26, 115, 205, ${0.18 - cloudiness * 0.06}), rgba(73, 144, 209, ${0.24 - cloudiness * 0.08}))`,
+  };
+}


### PR DESCRIPTION
## What changed
- add a cached server-side National Weather Service integration for Steven's fixed San Jose location
- combine fresh airport observations with numeric NWS forecast sky cover
- drive atmospheric haze, cloud density, cloud color, and motion from current conditions
- preserve a distinctly blue clear-day palette with a polished-realism cap on washout
- show the current condition in the desktop home-time label
- retain an entirely local blue fallback when NWS is unavailable

## Provider choice
The NWS API is keyless, open for any purpose, and supports the fixed U.S. location. The browser calls the portfolio API route rather than NWS directly, allowing provider-required User-Agent identification and shared caching.

## Validation
- 8 Node tests passed
- npm run typecheck
- npm run lint
- npm run build
- production-build smoke test of /api/weather returned a fresh Clear KSJC observation with 0% cloud cover and expected cache headers